### PR TITLE
fix(api): refactor document loaders for generic ingestion and extract…

### DIFF
--- a/nesis/api/core/document_loaders/loader_helper.py
+++ b/nesis/api/core/document_loaders/loader_helper.py
@@ -1,20 +1,31 @@
-import uuid
+import datetime
 import json
-from nesis.api.core.models.entities import Document
-from nesis.api.core.util.dateutil import strptime
 import logging
-from nesis.api.core.services.util import get_document, delete_document
+import uuid
+from typing import Optional, Dict, Any, Callable
+
+import nesis.api.core.util.http as http
+from nesis.api.core.document_loaders.runners import (
+    IngestRunner,
+    ExtractRunner,
+    RagRunner,
+)
+from nesis.api.core.models.entities import Document, Datasource
+from nesis.api.core.services.util import delete_document
+from nesis.api.core.services.util import (
+    get_document,
+)
+from nesis.api.core.util.constants import DEFAULT_DATETIME_FORMAT
+from nesis.api.core.util.dateutil import strptime
 
 _LOG = logging.getLogger(__name__)
 
 
 def upload_document_to_llm(upload_document, file_metadata, rag_endpoint, http_client):
-    return _upload_document_to_pgpt(
-        upload_document, file_metadata, rag_endpoint, http_client
-    )
+    return _upload_document(upload_document, file_metadata, rag_endpoint, http_client)
 
 
-def _upload_document_to_pgpt(upload_document, file_metadata, rag_endpoint, http_client):
+def _upload_document(upload_document, file_metadata, rag_endpoint, http_client):
     document_id = file_metadata["unique_id"]
     file_name = file_metadata["name"]
 
@@ -51,3 +62,101 @@ def _upload_document_to_pgpt(upload_document, file_metadata, rag_endpoint, http_
     request_object = {"file_name": file_name, "text": upload_document.page_content}
     response = http_client.post(url=f"{rag_endpoint}/v1/ingest", payload=request_object)
     return json.loads(response)
+
+
+class DocumentProcessor(object):
+    def __init__(
+        self,
+        config,
+        http_client: http.HttpClient,
+        datasource: Datasource,
+    ):
+        self._datasource = datasource
+
+        # This is left package public for testing
+        self._extract_runner: ExtractRunner = Optional[None]
+        _ingest_runner = IngestRunner(config=config, http_client=http_client)
+
+        if self._datasource.connection.get("destination") is not None:
+            self._extract_runner = ExtractRunner(
+                config=config,
+                http_client=http_client,
+                destination=self._datasource.connection.get("destination"),
+            )
+
+        self._mode = self._datasource.connection.get("mode") or "ingest"
+
+        match self._mode:
+            case "ingest":
+                self._ingest_runners: list[RagRunner] = [_ingest_runner]
+            case "extract":
+                self._ingest_runners: list[RagRunner] = [self._extract_runner]
+            case _:
+                raise ValueError(
+                    f"Invalid mode {self._mode}. Expected 'ingest' or 'extract'"
+                )
+
+    def sync(
+        self,
+        endpoint: str,
+        file_path: str,
+        last_modified: datetime.datetime,
+        metadata: Dict[str, Any],
+        store_metadata: Dict[str, Any],
+    ) -> None:
+        """
+        Here we check if this file has been updated.
+        If the file has been updated, we delete it from the vector store and re-ingest the new updated file
+        """
+        document_id = str(
+            uuid.uuid5(
+                uuid.NAMESPACE_DNS, f"{self._datasource.uuid}:{metadata['self_link']}"
+            )
+        )
+        document: Document = get_document(document_id=document_id)
+        for _ingest_runner in self._ingest_runners:
+            try:
+                response_json = _ingest_runner.run(
+                    file_path=file_path,
+                    metadata=metadata,
+                    document_id=None if document is None else document.uuid,
+                    last_modified=last_modified.replace(tzinfo=None).replace(
+                        microsecond=0
+                    ),
+                    datasource=self._datasource,
+                )
+            except ValueError:
+                _LOG.warning(f"File {file_path} ingestion failed", exc_info=True)
+                response_json = None
+            except UserWarning:
+                _LOG.warning(f"File {file_path} is already processing")
+                continue
+
+            if response_json is None:
+                _LOG.warning("No response from ingest runner received")
+                continue
+
+            _ingest_runner.save(
+                document_id=document_id,
+                datasource_id=self._datasource.uuid,
+                filename=store_metadata["filename"],
+                base_uri=endpoint,
+                rag_metadata=response_json,
+                store_metadata=store_metadata,
+                last_modified=last_modified,
+            )
+
+    def unsync(self, clean: Callable) -> None:
+        endpoint = self._datasource.connection.get("endpoint")
+
+        for _ingest_runner in self._ingest_runners:
+            documents = _ingest_runner.get(base_uri=endpoint)
+            for document in documents:
+                store_metadata = document.store_metadata
+                try:
+                    rag_metadata = document.rag_metadata
+                except AttributeError:
+                    rag_metadata = document.extract_metadata
+
+                if clean(store_metadata=store_metadata):
+                    _ingest_runner.delete(document=document, rag_metadata=rag_metadata)

--- a/nesis/api/core/document_loaders/runners.py
+++ b/nesis/api/core/document_loaders/runners.py
@@ -74,14 +74,16 @@ class ExtractRunner(RagRunner):
     ) -> Union[Dict[str, Any], None]:
 
         if document_id is not None:
+            _LOG.debug(f"Checking if document {document_id} is modified")
             _is_modified = self._is_modified(
                 document_id=document_id, last_modified=last_modified
             )
             if _is_modified is None or not _is_modified:
+                _LOG.debug(f"Document {document_id} is not modified")
                 return
 
         url = f"{self._rag_endpoint}/v1/extractions/text"
-
+        _LOG.debug(f"Document {document_id} is modified, performing extraction")
         response = self._http_client.upload(
             url=url,
             filepath=file_path,

--- a/nesis/api/core/document_loaders/samba.py
+++ b/nesis/api/core/document_loaders/samba.py
@@ -1,55 +1,232 @@
-import uuid
+import logging
 import pathlib
-import json
-import memcache
+import uuid
+from concurrent.futures import as_completed
 from datetime import datetime
 from typing import Dict, Any
 
+import memcache
 import smbprotocol
 from smbclient import scandir, stat, shutil
 
-import logging
-from nesis.api.core.models.entities import Document
-from nesis.api.core.services import util
-from nesis.api.core.services.util import (
-    save_document,
-    get_document,
-    delete_document,
-    get_documents,
-    ValidationException,
-    ingest_file,
-)
+from nesis.api.core.document_loaders.loader_helper import DocumentProcessor
+from nesis.api.core.models.entities import Datasource
 from nesis.api.core.util import http, clean_control, isblank
+from nesis.api.core.util.concurrency import IOBoundPool
 from nesis.api.core.util.constants import DEFAULT_DATETIME_FORMAT, DEFAULT_SAMBA_PORT
-from nesis.api.core.util.dateutil import strptime
 
 _LOG = logging.getLogger(__name__)
 
 
-def fetch_documents(
-    connection: Dict[str, str],
-    rag_endpoint: str,
-    http_client: http.HttpClient,
-    cache_client: memcache.Client,
-    metadata: Dict[str, Any],
-) -> None:
-    try:
-        _sync_samba_documents(
-            connection=connection,
-            rag_endpoint=rag_endpoint,
-            http_client=http_client,
-            metadata=metadata,
-            cache_client=cache_client,
-        )
-    except:
-        _LOG.exception(f"Error syncing documents")
+class Processor(DocumentProcessor):
+    def __init__(
+        self,
+        config,
+        http_client: http.HttpClient,
+        cache_client: memcache.Client,
+        datasource: Datasource,
+    ):
+        super().__init__(config, http_client, datasource)
+        self._config = config
+        self._http_client = http_client
+        self._cache_client = cache_client
+        self._datasource = datasource
+        self._futures = []
 
-    try:
-        _unsync_samba_documents(
-            connection=connection, rag_endpoint=rag_endpoint, http_client=http_client
+    def run(self, metadata: Dict[str, Any]):
+        connection = self._datasource.connection
+        try:
+            self._sync_samba_documents(
+                metadata=metadata,
+            )
+        except:
+            _LOG.exception(f"Error syncing documents")
+
+        try:
+            self._unsync_samba_documents(
+                connection=connection,
+            )
+        except:
+            _LOG.exception(f"Error unsyncing documents")
+
+        for future in as_completed(self._futures):
+            try:
+                future.result()
+            except:
+                _LOG.warning(future.exception())
+
+    def _sync_samba_documents(self, metadata):
+
+        connection = self._datasource.connection
+
+        username = connection["user"]
+        password = connection["password"]
+        endpoint = connection["endpoint"]
+        port = connection["port"]
+        # These are any folder specified to scope the sync to
+        dataobjects = connection.get("dataobjects") or ""
+
+        dataobjects_parts = [do.strip() for do in dataobjects.split(",")]
+
+        try:
+            file_shares = scandir(
+                endpoint, username=username, password=password, port=port
+            )
+        except Exception as ex:
+            _LOG.exception(
+                f"Error while scanning share on samba server {endpoint} - {ex}"
+            )
+            raise
+
+        work_dir = f"/tmp/{uuid.uuid4()}"
+        pathlib.Path(work_dir).mkdir(parents=True)
+
+        for file_share in file_shares:
+            if (
+                len(dataobjects_parts) > 0
+                and file_share.is_dir()
+                and file_share.name not in dataobjects_parts
+            ):
+                continue
+            try:
+
+                _metadata = {
+                    **(metadata or {}),
+                    "file_name": file_share.path,
+                }
+
+                self._futures.append(
+                    IOBoundPool.submit(
+                        self._process_file,
+                        connection=connection,
+                        file_share=file_share,
+                        work_dir=work_dir,
+                        metadata=_metadata,
+                    )
+                )
+
+            except:
+                _LOG.warning(
+                    f"Error fetching and updating documents from shared_file share {file_share.path} - ",
+                    exc_info=True,
+                )
+
+    def _process_file(self, connection, file_share, work_dir, metadata):
+        username = connection["user"]
+        password = connection["password"]
+        endpoint = connection["endpoint"]
+        port = connection["port"]
+
+        if file_share.is_dir():
+            if not file_share.name.startswith("."):
+                dir_files = scandir(
+                    file_share.path, username=username, password=password, port=port
+                )
+                for dir_file in dir_files:
+                    self._process_file(
+                        connection=connection,
+                        file_share=dir_file,
+                        work_dir=work_dir,
+                        metadata=metadata,
+                    )
+            return
+
+        file_name = file_share.name
+        file_stats = stat(
+            file_share.path, username=username, password=password, port=port
         )
-    except Exception as ex:
-        _LOG.exception(f"Error unsyncing documents")
+        last_change_datetime = datetime.fromtimestamp(file_stats.st_chgtime)
+
+        try:
+            file_path = f"{work_dir}/{file_share.name}"
+            file_unique_id = f"{uuid.uuid5(uuid.NAMESPACE_DNS, file_share.path)}"
+
+            _LOG.info(
+                f"Starting syncing shared_file {file_name} in shared directory share {file_share.path}"
+            )
+
+            try:
+                shutil.copyfile(
+                    file_share.path,
+                    file_path,
+                    username=username,
+                    password=password,
+                    port=port,
+                )
+                self_link = file_share.path
+                _lock_key = clean_control(f"{__name__}/locks/{self_link}")
+
+                metadata["self_link"] = self_link
+
+                if self._cache_client.add(key=_lock_key, val=_lock_key, time=30 * 60):
+                    try:
+                        self.sync(
+                            endpoint,
+                            file_path,
+                            last_modified=last_change_datetime,
+                            metadata=metadata,
+                            store_metadata={
+                                "shared_folder": file_share.name,
+                                "file_path": file_share.path,
+                                "filename": file_share.path,
+                                "file_id": file_unique_id,
+                                "size": file_stats.st_size,
+                                "name": file_name,
+                                "last_modified": last_change_datetime.strftime(
+                                    DEFAULT_DATETIME_FORMAT
+                                ),
+                            },
+                        )
+                    finally:
+                        self._cache_client.delete(_lock_key)
+                else:
+                    _LOG.info(f"Document {self_link} is already processing")
+
+            except:
+                _LOG.warning(
+                    f"Failed to copy contents of shared_file {file_name} from shared location {file_share.path}",
+                    exc_info=True,
+                )
+                return
+
+            _LOG.info(
+                f"Done syncing shared_file {file_name} in location {file_share.path}"
+            )
+        except Exception as ex:
+            _LOG.warn(
+                f"Error when getting and ingesting shared_file {file_name} - {ex}",
+                exc_info=True,
+            )
+
+    def _unsync_samba_documents(self, connection):
+        username = connection["user"]
+        password = connection["password"]
+        port = connection["port"]
+
+        def clean(**kwargs):
+            store_metadata = kwargs["store_metadata"]
+            file_path = store_metadata["file_path"]
+            try:
+                stat(file_path, username=username, password=password, port=port)
+                return False
+            except Exception as error:
+                if "No such file" in str(error):
+                    return True
+                else:
+                    raise
+
+        try:
+            self.unsync(clean=clean)
+        except:
+            _LOG.warning("Error fetching and updating documents", exc_info=True)
+
+
+def _connect_samba_server(connection):
+    username = connection.get("user")
+    password = connection.get("password")
+    endpoint = connection.get("endpoint")
+    port = connection.get("port")
+    next(scandir(endpoint, username=username, password=password, port=port))
 
 
 def validate_connection_info(connection: Dict[str, Any]) -> Dict[str, Any]:
@@ -75,242 +252,3 @@ def validate_connection_info(connection: Dict[str, Any]) -> Dict[str, Any]:
         for key, val in connection.items()
         if key in _valid_keys and not isblank(connection[key])
     }
-
-
-def _connect_samba_server(connection):
-    username = connection.get("user")
-    password = connection.get("password")
-    endpoint = connection.get("endpoint")
-    port = connection.get("port")
-    next(scandir(endpoint, username=username, password=password, port=port))
-
-
-def _sync_samba_documents(
-    connection, rag_endpoint, http_client, metadata, cache_client
-):
-
-    username = connection["user"]
-    password = connection["password"]
-    endpoint = connection["endpoint"]
-    port = connection["port"]
-    # These are any folder specified to scope the sync to
-    dataobjects = connection.get("dataobjects") or ""
-
-    dataobjects_parts = [do.strip() for do in dataobjects.split(",")]
-
-    try:
-        file_shares = scandir(endpoint, username=username, password=password, port=port)
-    except Exception as ex:
-        _LOG.exception(f"Error while scanning share on samba server {endpoint} - {ex}")
-        raise
-
-    work_dir = f"/tmp/{uuid.uuid4()}"
-    pathlib.Path(work_dir).mkdir(parents=True)
-
-    for file_share in file_shares:
-        if (
-            len(dataobjects_parts) > 0
-            and file_share.is_dir()
-            and file_share.name not in dataobjects_parts
-        ):
-            continue
-        try:
-            self_link = file_share.path
-            _lock_key = clean_control(f"{__name__}/locks/{self_link}")
-
-            if cache_client.add(key=_lock_key, val=_lock_key, time=30 * 60):
-                _metadata = {
-                    **(metadata or {}),
-                    "file_name": file_share.path,
-                    "self_link": self_link,
-                }
-                try:
-                    _process_file(
-                        connection=connection,
-                        file_share=file_share,
-                        work_dir=work_dir,
-                        http_client=http_client,
-                        rag_endpoint=rag_endpoint,
-                        metadata=_metadata,
-                    )
-                finally:
-                    cache_client.delete(_lock_key)
-            else:
-                _LOG.info(f"Document {self_link} is already processing")
-        except:
-            _LOG.warn(
-                f"Error fetching and updating documents from shared_file share {file_share.path} - ",
-                exc_info=True,
-            )
-
-    _LOG.info(
-        f"Completed syncing files from samba server {endpoint} "
-        f"to endpoint {rag_endpoint}"
-    )
-
-
-def _process_file(
-    connection, file_share, work_dir, http_client, rag_endpoint, metadata
-):
-    username = connection["user"]
-    password = connection["password"]
-    endpoint = connection["endpoint"]
-    port = connection["port"]
-
-    if file_share.is_dir():
-        if not file_share.name.startswith("."):
-            dir_files = scandir(
-                file_share.path, username=username, password=password, port=port
-            )
-            for dir_file in dir_files:
-                _process_file(
-                    connection=connection,
-                    file_share=dir_file,
-                    work_dir=work_dir,
-                    http_client=http_client,
-                    rag_endpoint=rag_endpoint,
-                    metadata=metadata,
-                )
-        return
-
-    file_name = file_share.name
-    file_stats = stat(file_share.path, username=username, password=password, port=port)
-    last_change_datetime = datetime.fromtimestamp(file_stats.st_chgtime)
-
-    try:
-        file_path = f"{work_dir}/{file_share.name}"
-        file_unique_id = f"{uuid.uuid5(uuid.NAMESPACE_DNS, file_share.path)}"
-
-        _LOG.info(
-            f"Starting syncing shared_file {file_name} in shared directory share {file_share.path}"
-        )
-
-        try:
-            shutil.copyfile(
-                file_share.path,
-                file_path,
-                username=username,
-                password=password,
-                port=port,
-            )
-        except Exception as ex:
-            _LOG.warn(
-                f"Failed to copy contents of shared_file {file_name} from shared location {file_share.path}",
-                exc_info=True,
-            )
-            return
-
-        """
-        Here we check if this file has been updated.
-        If the file has been updated, we delete it from the vector store and re-ingest the new updated file
-        """
-        document: Document = get_document(document_id=file_unique_id)
-        if document and document.base_uri == endpoint:
-            store_metadata = document.store_metadata
-            if store_metadata and store_metadata.get("last_modified"):
-                if not strptime(date_string=store_metadata["last_modified"]).replace(
-                    tzinfo=None
-                ) < last_change_datetime.replace(tzinfo=None).replace(microsecond=0):
-                    _LOG.debug(f"Skipping shared_file {file_name} already up to date")
-                    return
-                rag_metadata: dict = document.rag_metadata
-                if rag_metadata is None:
-                    return
-                for document_data in rag_metadata.get("data") or []:
-                    try:
-                        util.un_ingest_file(
-                            http_client=http_client,
-                            endpoint=rag_endpoint,
-                            doc_id=document_data["doc_id"],
-                        )
-                    except:
-                        _LOG.warn(
-                            f"Failed to delete document {document_data['doc_id']}",
-                            exc_info=True,
-                        )
-                try:
-                    delete_document(document_id=file_unique_id)
-                except:
-                    _LOG.warn(
-                        f"Failed to delete shared_file {file_name}'s record. Continuing anyway...",
-                        exc_info=True,
-                    )
-
-        file_metadata = {
-            "shared_folder": file_share.name,
-            "file_path": file_share.path,
-            "file_id": file_unique_id,
-            "size": file_stats.st_size,
-            "name": file_name,
-            "last_modified": last_change_datetime.strftime(DEFAULT_DATETIME_FORMAT),
-        }
-
-        try:
-            response = ingest_file(
-                http_client=http_client,
-                endpoint=rag_endpoint,
-                metadata=metadata,
-                file_path=file_path,
-            )
-        except UserWarning:
-            _LOG.debug(f"File {file_path} is already processing")
-            return
-        response_json = json.loads(response)
-
-        save_document(
-            document_id=file_unique_id,
-            filename=file_share.path,
-            base_uri=endpoint,
-            rag_metadata=response_json,
-            store_metadata=file_metadata,
-        )
-
-        _LOG.info(f"Done syncing shared_file {file_name} in location {file_share.path}")
-    except Exception as ex:
-        _LOG.warn(
-            f"Error when getting and ingesting shared_file {file_name} - {ex}",
-            exc_info=True,
-        )
-    _LOG.info(
-        f"Completed syncing files from shared_file share {file_share.path} to endpoint {rag_endpoint}"
-    )
-
-
-def _unsync_samba_documents(connection, rag_endpoint, http_client):
-    try:
-        username = connection["user"]
-        password = connection["password"]
-        endpoint = connection["endpoint"]
-        port = connection["port"]
-
-        work_dir = f"/tmp/{uuid.uuid4()}"
-        pathlib.Path(work_dir).mkdir(parents=True)
-
-        documents = get_documents(base_uri=endpoint)
-        for document in documents:
-            store_metadata = document.store_metadata
-            rag_metadata = document.rag_metadata
-
-            file_path = store_metadata["file_path"]
-            try:
-                stat(file_path, username=username, password=password, port=port)
-            except smbprotocol.exceptions.SMBOSError as error:
-                if "No such file" not in str(error):
-                    raise
-                try:
-                    http_client.deletes(
-                        [
-                            f"{rag_endpoint}/v1/ingest/documents/{document_data['doc_id']}"
-                            for document_data in rag_metadata.get("data") or []
-                        ]
-                    )
-                    _LOG.info(f"Deleting document {document.filename}")
-                    delete_document(document_id=document.id)
-                except:
-                    _LOG.warning(
-                        f"Failed to delete document {document.filename}",
-                        exc_info=True,
-                    )
-        _LOG.info(f"Completed unsyncing files from endpoint {rag_endpoint}")
-    except:
-        _LOG.warn("Error fetching and updating documents", exc_info=True)

--- a/nesis/api/core/tasks/document_management.py
+++ b/nesis/api/core/tasks/document_management.py
@@ -51,28 +51,35 @@ def ingest_datasource(**kwargs) -> None:
             minio_ingestor.run(metadata=metadata)
 
         case DatasourceType.SHAREPOINT:
-            sharepoint.fetch_documents(
-                datasource=datasource,
-                rag_endpoint=rag_endpoint,
+
+            ingestor = sharepoint.Processor(
+                config=config,
                 http_client=http_client,
                 cache_client=cache_client,
-                metadata={"datasource": datasource.name},
+                datasource=datasource,
             )
+
+            ingestor.run(metadata=metadata)
         case DatasourceType.WINDOWS_SHARE:
-            samba.fetch_documents(
-                connection=datasource.connection,
-                rag_endpoint=rag_endpoint,
+
+            ingestor = samba.Processor(
+                config=config,
                 http_client=http_client,
-                metadata={"datasource": datasource.name},
                 cache_client=cache_client,
-            )
-        case DatasourceType.S3:
-            s3.fetch_documents(
                 datasource=datasource,
-                rag_endpoint=rag_endpoint,
-                http_client=http_client,
-                metadata={"datasource": datasource.name},
-                cache_client=cache_client,
             )
+
+            ingestor.run(metadata=metadata)
+
+        case DatasourceType.S3:
+            minio_ingestor = s3.Processor(
+                config=config,
+                http_client=http_client,
+                cache_client=cache_client,
+                datasource=datasource,
+            )
+
+            minio_ingestor.run(metadata=metadata)
+
         case _:
             raise ValueError("Invalid datasource type")

--- a/nesis/api/tests/core/document_loaders/test_minio.py
+++ b/nesis/api/tests/core/document_loaders/test_minio.py
@@ -400,11 +400,17 @@ def test_update_ingest_documents(
     session.add(datasource)
     session.commit()
 
-    # The document record
+    self_link = "http://localhost:4566/my-test-bucket/SomeName"
 
+    # The document record
     document = Document(
         base_uri="http://localhost:4566",
-        document_id="d41d8cd98f00b204e9800998ecf8427e",
+        document_id=str(
+            uuid.uuid5(
+                uuid.NAMESPACE_DNS,
+                f"{datasource.uuid}:{self_link}",
+            )
+        ),
         filename="invalid.pdf",
         rag_metadata={"data": [{"doc_id": str(uuid.uuid4())}]},
         store_metadata={
@@ -449,8 +455,8 @@ def test_update_ingest_documents(
     )
 
     # The document would be deleted from the rag engine
-    _, upload_kwargs = http_client.deletes.call_args_list[0]
-    urls = upload_kwargs["urls"]
+    _, deletes_kwargs = http_client.deletes.call_args_list[0]
+    urls = deletes_kwargs["urls"]
 
     assert (
         urls[0]
@@ -474,7 +480,7 @@ def test_update_ingest_documents(
         {
             "datasource": "documents",
             "file_name": "my-test-bucket/SomeName",
-            "self_link": "http://localhost:4566/my-test-bucket/SomeName",
+            "self_link": self_link,
         },
     )
 

--- a/nesis/api/tests/core/document_loaders/test_s3.py
+++ b/nesis/api/tests/core/document_loaders/test_s3.py
@@ -13,6 +13,7 @@ from sqlalchemy.orm.session import Session
 import nesis.api.core.services as services
 import nesis.api.core.document_loaders.s3 as s3
 from nesis.api import tests
+from nesis.api.core.document_loaders.stores import SqlDocumentStore
 from nesis.api.core.models import DBSession
 from nesis.api.core.models import initialize_engine
 from nesis.api.core.models.entities import (
@@ -107,12 +108,14 @@ def test_sync_documents(
     ]
     s3_client.get_paginator.return_value = paginator
 
-    s3.fetch_documents(
-        datasource=datasource,
+    ingestor = s3.Processor(
+        config=tests.config,
         http_client=http_client,
-        metadata={"datasource": "documents"},
-        rag_endpoint="http://localhost:8080",
         cache_client=cache,
+        datasource=datasource,
+    )
+    ingestor.run(
+        metadata={"datasource": "documents"},
     )
 
     _, upload_kwargs = http_client.upload.call_args_list[0]
@@ -150,7 +153,7 @@ def test_update_sync_documents(
         "connection": {
             "endpoint": "http://localhost:4566",
             "region": "us-east-1",
-            "dataobjects": "my-test-bucket",
+            "dataobjects": "some-bucket",
         },
     }
 
@@ -164,17 +167,26 @@ def test_update_sync_documents(
     session.add(datasource)
     session.commit()
 
+    self_link = "http://localhost:4566/some-bucket/invalid.pdf"
+
+    # The document record
     document = Document(
         base_uri="http://localhost:4566",
-        document_id="d41d8cd98f00b204e9800998ecf8427e",
+        document_id=str(
+            uuid.uuid5(
+                uuid.NAMESPACE_DNS,
+                f"{datasource.uuid}:{self_link}",
+            )
+        ),
         filename="invalid.pdf",
         rag_metadata={"data": [{"doc_id": str(uuid.uuid4())}]},
         store_metadata={
             "bucket_name": "some-bucket",
-            "object_name": "file/path.pdf",
+            "object_name": "invalid.pdf",
             "last_modified": "2023-07-18 06:40:07",
         },
-        last_modified=datetime.datetime.utcnow(),
+        last_modified=strptime("2023-07-19 06:40:07"),
+        datasource_id=datasource.uuid,
     )
 
     session.add(document)
@@ -191,8 +203,8 @@ def test_update_sync_documents(
             "KeyCount": 1,
             "Contents": [
                 {
-                    "Key": "image.jpg",
-                    "LastModified": strptime("2023-07-19 06:40:07"),
+                    "Key": "invalid.pdf",
+                    "LastModified": strptime("2023-07-20 06:40:07"),
                     "ETag": "d41d8cd98f00b204e9800998ecf8427e",
                     "Size": 0,
                     "StorageClass": "STANDARD",
@@ -206,22 +218,24 @@ def test_update_sync_documents(
     ]
     s3_client.get_paginator.return_value = paginator
 
-    s3.fetch_documents(
-        datasource=datasource,
+    ingestor = s3.Processor(
+        config=tests.config,
         http_client=http_client,
-        metadata={"datasource": "documents"},
-        rag_endpoint="http://localhost:8080",
         cache_client=cache,
+        datasource=datasource,
+    )
+
+    ingestor.run(
+        metadata={"datasource": "documents"},
     )
 
     # The document would be deleted from the rag engine
-    _, upload_kwargs = http_client.delete.call_args_list[0]
-    url = upload_kwargs["url"]
+    _, deletes_kwargs = http_client.deletes.call_args_list[0]
+    url = deletes_kwargs["urls"]
 
-    assert (
-        url
-        == f"http://localhost:8080/v1/ingest/documents/{document.rag_metadata['data'][0]['doc_id']}"
-    )
+    assert url == [
+        f"http://localhost:8080/v1/ingest/documents/{document.rag_metadata['data'][0]['doc_id']}"
+    ]
 
     # And then re-ingested
     _, upload_kwargs = http_client.upload.call_args_list[0]
@@ -231,21 +245,22 @@ def test_update_sync_documents(
     field = upload_kwargs["field"]
 
     assert url == f"http://localhost:8080/v1/ingest/files"
-    assert file_path.endswith("image.jpg")
+    assert file_path.endswith("invalid.pdf")
     assert field == "file"
     ut.TestCase().assertDictEqual(
         metadata,
         {
             "datasource": "documents",
-            "file_name": "my-test-bucket/image.jpg",
-            "self_link": "http://localhost:4566/my-test-bucket/image.jpg",
+            "file_name": "some-bucket/invalid.pdf",
+            "self_link": self_link,
         },
     )
 
     # The document has now been updated
     documents = session.query(Document).all()
     assert len(documents) == 1
-    assert documents[0].store_metadata["last_modified"] == "2023-07-19 06:40:07"
+    assert documents[0].store_metadata["last_modified"] == "2023-07-20 06:40:07"
+    assert str(documents[0].last_modified) == "2023-07-20 06:40:07"
 
 
 @mock.patch("nesis.api.core.document_loaders.s3.boto3.client")
@@ -260,8 +275,6 @@ def test_unsync_s3_documents(
         "engine": "s3",
         "connection": {
             "endpoint": "http://localhost:4566",
-            # "user": "test",
-            # "password": "test",
             "region": "us-east-1",
             "dataobjects": "some-non-existing-bucket",
         },
@@ -299,12 +312,15 @@ def test_unsync_s3_documents(
     documents = session.query(Document).all()
     assert len(documents) == 1
 
-    s3.fetch_documents(
-        datasource=datasource,
+    ingestor = s3.Processor(
+        config=tests.config,
         http_client=http_client,
-        metadata={"datasource": "documents"},
-        rag_endpoint="http://localhost:8080",
         cache_client=cache,
+        datasource=datasource,
+    )
+
+    ingestor.run(
+        metadata={"datasource": "documents"},
     )
 
     _, upload_kwargs = http_client.deletes.call_args_list[0]
@@ -316,3 +332,189 @@ def test_unsync_s3_documents(
     )
     documents = session.query(Document).all()
     assert len(documents) == 0
+
+
+@mock.patch("nesis.api.core.document_loaders.s3.boto3.client")
+def test_extract_documents(
+    client: mock.MagicMock, cache: mock.MagicMock, session: Session
+) -> None:
+    destination_sql_url = tests.config["database"]["url"]
+    # destination_sql_url = "mssql+pymssql://sa:Pa55woR.d12345@localhost:11433/master"
+    data = {
+        "name": "s3 documents",
+        "engine": "s3",
+        "connection": {
+            "endpoint": "https://s3.endpoint",
+            "access_key": "",
+            "secret_key": "",
+            "dataobjects": "buckets",
+            "mode": "extract",
+            "destination": {
+                "sql": {"url": destination_sql_url},
+            },
+        },
+    }
+
+    datasource = Datasource(
+        name=data["name"],
+        connection=data["connection"],
+        source_type=DatasourceType.S3,
+        status=DatasourceStatus.ONLINE,
+    )
+
+    session.add(datasource)
+    session.commit()
+
+    http_client = mock.MagicMock()
+    http_client.upload.return_value = json.dumps({})
+    s3_client = mock.MagicMock()
+
+    client.return_value = s3_client
+    paginator = mock.MagicMock()
+    paginator.paginate.return_value = [
+        {
+            "KeyCount": 1,
+            "Contents": [
+                {
+                    "Key": "image.jpg",
+                    "LastModified": strptime("2023-07-18 06:40:07"),
+                    "ETag": '"d41d8cd98f00b204e9800998ecf8427e"',
+                    "Size": 0,
+                    "StorageClass": "STANDARD",
+                    "Owner": {
+                        "DisplayName": "webfile",
+                        "ID": "75aa57f09aa0c8caeab4f8c24e99d10f8e7faeebf76c078efc7c6caea54ba06a",
+                    },
+                }
+            ],
+        }
+    ]
+    s3_client.get_paginator.return_value = paginator
+
+    ingestor = s3.Processor(
+        config=tests.config,
+        http_client=http_client,
+        cache_client=cache,
+        datasource=datasource,
+    )
+
+    extract_store = SqlDocumentStore(
+        url=data["connection"]["destination"]["sql"]["url"]
+    )
+
+    with Session(extract_store._engine) as session:
+        initial_count = len(
+            session.query(ingestor._extract_runner._extraction_store.Store)
+            .filter()
+            .all()
+        )
+
+    ingestor.run(
+        metadata={"datasource": "documents"},
+    )
+
+    _, upload_kwargs = http_client.upload.call_args_list[0]
+    url = upload_kwargs["url"]
+    metadata = upload_kwargs["metadata"]
+    field = upload_kwargs["field"]
+
+    assert url == "http://localhost:8080/v1/extractions/text"
+    assert field == "file"
+    ut.TestCase().assertDictEqual(
+        metadata,
+        {
+            "datasource": "documents",
+            "file_name": "buckets/image.jpg",
+            "self_link": "https://s3.endpoint/buckets/image.jpg",
+        },
+    )
+
+    with Session(extract_store._engine) as session:
+        all_documents = (
+            session.query(ingestor._extract_runner._extraction_store.Store)
+            .filter()
+            .all()
+        )
+        assert len(all_documents) == initial_count + 1
+
+
+@mock.patch("nesis.api.core.document_loaders.s3.boto3.client")
+def test_unextract_documents(
+    client: mock.MagicMock, cache: mock.MagicMock, session: Session
+) -> None:
+    """
+    Test deleting of s3 documents from the rag engine if they have been deleted from the s3 bucket
+    """
+    destination_sql_url = tests.config["database"]["url"]
+    data = {
+        "name": "s3 documents",
+        "engine": "s3",
+        "connection": {
+            "endpoint": "https://s3.endpoint",
+            "access_key": "",
+            "secret_key": "",
+            "dataobjects": "buckets",
+            "mode": "extract",
+            "destination": {
+                "sql": {"url": destination_sql_url},
+            },
+        },
+    }
+    datasource = Datasource(
+        name=data["name"],
+        connection=data["connection"],
+        source_type=DatasourceType.MINIO,
+        status=DatasourceStatus.ONLINE,
+    )
+
+    session.add(datasource)
+    session.commit()
+
+    http_client = mock.MagicMock()
+    s3_client = mock.MagicMock()
+
+    client.return_value = s3_client
+    s3_client.head_object.side_effect = Exception("HeadObject Not Found")
+
+    minio_ingestor = s3.Processor(
+        config=tests.config,
+        http_client=http_client,
+        cache_client=cache,
+        datasource=datasource,
+    )
+
+    extract_store = SqlDocumentStore(
+        url=data["connection"]["destination"]["sql"]["url"]
+    )
+
+    with Session(extract_store._engine) as session:
+        session.query(minio_ingestor._extract_runner._extraction_store.Store).delete()
+        document = minio_ingestor._extract_runner._extraction_store.Store()
+        document.base_uri = data["connection"]["endpoint"]
+        document.uuid = str(uuid.uuid4())
+        document.filename = "invalid.pdf"
+        document.extract_metadata = {"data": [{"doc_id": str(uuid.uuid4())}]}
+        document.store_metadata = {
+            "bucket_name": "some-bucket",
+            "object_name": "file/path.pdf",
+        }
+        document.last_modified = datetime.datetime.utcnow()
+
+        session.add(document)
+        session.commit()
+
+        initial_count = len(
+            session.query(minio_ingestor._extract_runner._extraction_store.Store)
+            .filter()
+            .all()
+        )
+
+    minio_ingestor.run(
+        metadata={"datasource": "documents"},
+    )
+
+    with Session(extract_store._engine) as session:
+        documents = session.query(
+            minio_ingestor._extract_runner._extraction_store.Store
+        ).all()
+        assert len(documents) == initial_count - 1

--- a/nesis/api/tests/tasks/test_document_management.py
+++ b/nesis/api/tests/tasks/test_document_management.py
@@ -97,15 +97,9 @@ def test_ingest_datasource_minio(
 
 
 @mock.patch("nesis.api.core.document_loaders.samba.scandir")
-@mock.patch("nesis.api.core.tasks.document_management.samba._unsync_samba_documents")
-@mock.patch("nesis.api.core.tasks.document_management.samba._sync_samba_documents")
+@mock.patch("nesis.api.core.tasks.document_management.samba.Processor")
 def test_ingest_datasource_samba(
-    _sync_samba_documents: mock.MagicMock,
-    _unsync_samba_documents: mock.MagicMock,
-    scandir,
-    tc,
-    cache_client,
-    http_client,
+    ingestor: mock.MagicMock, scandir, tc, cache_client, http_client
 ):
     """
     Test the ingestion happy path
@@ -117,7 +111,7 @@ def test_ingest_datasource_samba(
         password=tests.admin_password,
     )
     datasource: Datasource = create_datasource(
-        token=admin_user.token, datasource_type="windows_share"
+        token=admin_user.token, datasource_type="WINDOWS_SHARE"
     )
 
     ingest_datasource(
@@ -127,21 +121,9 @@ def test_ingest_datasource_samba(
         params={"datasource": {"id": datasource.uuid}},
     )
 
-    _, kwargs_sync_samba_documents = _sync_samba_documents.call_args_list[0]
-    assert (
-        kwargs_sync_samba_documents["rag_endpoint"] == tests.config["rag"]["endpoint"]
-    )
-    tc.assertDictEqual(kwargs_sync_samba_documents["connection"], datasource.connection)
+    _, kwargs_fetch_documents = ingestor.return_value.run.call_args_list[0]
     tc.assertDictEqual(
-        kwargs_sync_samba_documents["metadata"], {"datasource": datasource.name}
-    )
-
-    _, kwargs_unsync_samba_documents = _unsync_samba_documents.call_args_list[0]
-    assert (
-        kwargs_unsync_samba_documents["rag_endpoint"] == tests.config["rag"]["endpoint"]
-    )
-    tc.assertDictEqual(
-        kwargs_unsync_samba_documents["connection"], datasource.connection
+        kwargs_fetch_documents["metadata"], {"datasource": datasource.name}
     )
 
 
@@ -162,17 +144,8 @@ def test_ingest_datasource_invalid_datasource(
         assert "Invalid datasource" in str(ex_info)
 
 
-@mock.patch("nesis.api.core.document_loaders.s3.boto3.client")
-@mock.patch("nesis.api.core.tasks.document_management.s3._unsync_documents")
-@mock.patch("nesis.api.core.tasks.document_management.s3._sync_documents")
-def test_ingest_datasource_s3(
-    _sync_documents: mock.MagicMock,
-    _unsync_documents: mock.MagicMock,
-    client: mock.MagicMock(),
-    tc,
-    cache_client,
-    http_client,
-):
+@mock.patch("nesis.api.core.tasks.document_management.s3.Processor")
+def test_ingest_datasource_s3(ingestor: mock.MagicMock, tc, cache_client, http_client):
     """
     Test the ingestion happy path
     """
@@ -193,37 +166,15 @@ def test_ingest_datasource_s3(
         params={"datasource": {"id": datasource.uuid}},
     )
 
-    _, kwargs_sync_samba_documents = _sync_documents.call_args_list[0]
-    assert (
-        kwargs_sync_samba_documents["rag_endpoint"] == tests.config["rag"]["endpoint"]
-    )
-    assert kwargs_sync_samba_documents.get("datasource") is not None
-
+    _, kwargs_fetch_documents = ingestor.return_value.run.call_args_list[0]
     tc.assertDictEqual(
-        kwargs_sync_samba_documents["metadata"], {"datasource": datasource.name}
-    )
-
-    _, kwargs_unsync_samba_documents = _unsync_documents.call_args_list[0]
-    assert (
-        kwargs_unsync_samba_documents["rag_endpoint"] == tests.config["rag"]["endpoint"]
-    )
-    tc.assertDictEqual(
-        kwargs_unsync_samba_documents["connection"], datasource.connection
+        kwargs_fetch_documents["metadata"], {"datasource": datasource.name}
     )
 
 
-@mock.patch(
-    "nesis.api.core.tasks.document_management.sharepoint._unsync_sharepoint_documents"
-)
-@mock.patch(
-    "nesis.api.core.tasks.document_management.sharepoint._sync_sharepoint_documents"
-)
+@mock.patch("nesis.api.core.tasks.document_management.sharepoint.Processor")
 def test_ingest_datasource_sharepoint(
-    _sync_sharepoint_documents: mock.MagicMock,
-    _unsync_sharepoint_documents: mock.MagicMock,
-    tc,
-    cache_client,
-    http_client,
+    ingestor: mock.MagicMock, tc, cache_client, http_client
 ):
     """
     Test the ingestion happy path
@@ -245,24 +196,7 @@ def test_ingest_datasource_sharepoint(
         params={"datasource": {"id": datasource.uuid}},
     )
 
-    _, kwargs_sync_sharepoint_documents = _sync_sharepoint_documents.call_args_list[0]
-    assert (
-        kwargs_sync_sharepoint_documents["rag_endpoint"]
-        == tests.config["rag"]["endpoint"]
-    )
-    assert kwargs_sync_sharepoint_documents.get("datasource") is not None
-
+    _, kwargs_fetch_documents = ingestor.return_value.run.call_args_list[0]
     tc.assertDictEqual(
-        kwargs_sync_sharepoint_documents["metadata"], {"datasource": datasource.name}
-    )
-
-    _, kwargs_unsync_sharepoint_documents = _unsync_sharepoint_documents.call_args_list[
-        0
-    ]
-    assert (
-        kwargs_unsync_sharepoint_documents["rag_endpoint"]
-        == tests.config["rag"]["endpoint"]
-    )
-    tc.assertDictEqual(
-        kwargs_unsync_sharepoint_documents["connection"], datasource.connection
+        kwargs_fetch_documents["metadata"], {"datasource": datasource.name}
     )


### PR DESCRIPTION
…ion (#142)

This PR refactors all minio, sharepoint, samba, s3 document loaders
- to use generic document loaders.
- to have unique document_ids generated from from a combination of datasource and self_reference

Closes #143